### PR TITLE
Changes related to indexing IFC

### DIFF
--- a/src/Generators/BldrsEntityGenerator.cs
+++ b/src/Generators/BldrsEntityGenerator.cs
@@ -133,13 +133,16 @@ export {modifiers} class {data.Name} extends {superClass}
     {{
         return EntityTypesIfc.{data.Name.ToUpperInvariant()};
     }}
-
 {String.Join( '\n', data.Attributes.Where(attribute => !attribute.IsInverse && !attribute.IsDerived).Select( attribute => $"    {BldrsAttributeGenerator.AttributeDataString(attribute, typeData)};" ))}
 {propertyBuilder.ToString()}
     constructor(localID: number, internalReference: StepEntityInternalReference< EntityTypesIfc >, model: StepModelBase< EntityTypesIfc, StepEntityBase< EntityTypesIfc > > )
     {{
         super( localID, internalReference, model );
     }}
+
+    public static readonly query = [ { string.Join( ", ", data.ChildrenAndSelf().Where( childEntity => !childEntity.IsAbstract ).Select( childEntity => $"EntityTypesIfc.{childEntity.Name.ToUpperInvariant()}" ) ) } ];
+
+    public static readonly expectedType: EntityTypesIfc = EntityTypesIfc.{data.Name.ToUpperInvariant()};
 }}
 ";
 

--- a/src/Generators/BldrsWrapperTypeGenerator.cs
+++ b/src/Generators/BldrsWrapperTypeGenerator.cs
@@ -42,6 +42,10 @@ export class {data.Name} extends StepEntityBase< EntityTypesIfc >
     {{
         super( localID, internalReference, model );
     }}
+
+    public static readonly query = [ EntityTypesIfc.{data.Name.ToUpperInvariant()} ];
+
+    public static readonly expectedType: EntityTypesIfc = EntityTypesIfc.{data.Name.ToUpperInvariant()};
 }}
 ";            return result;
 

--- a/src/Generators/BlrdrsTypeIDGenerator.cs
+++ b/src/Generators/BlrdrsTypeIDGenerator.cs
@@ -81,7 +81,7 @@ namespace IFC4.Generators
 
             for (int where = 0; where < Names.Length; ++where)
             {
-                if (!IsAbstract[where])
+            //    if (!IsAbstract[where])
                 {
                     string localName = Names[where];
 
@@ -106,10 +106,22 @@ namespace IFC4.Generators
             }
 
             output.AppendLine($"{indent0}];");
+
+            output.AppendLine($"{indent0}let queries : {entityTypesName}[][]  = [");
+
+            for (int where = 0; where < Names.Length; ++where)
+            {
+                string localName = Names[where];
+
+                output.AppendLine($"{indent1}{localName}.query,");
+            }
+
+            output.AppendLine($"{indent0}];");
+
             output.AppendLine();
             output.AppendLine($"let parser = new StepParser< {entityTypesName} >( {entitySearchTypesName} );");
             output.AppendLine();
-            output.AppendLine($"let {name} = new StepEntitySchema< {entityTypesName} >( constructors, parser );");
+            output.AppendLine($"let {name} = new StepEntitySchema< {entityTypesName} >( constructors, parser, queries );");
             output.AppendLine();
             output.AppendLine($"export default {name};");
         }
@@ -140,13 +152,18 @@ namespace IFC4.Generators
 
             output.AppendLine($"{indent0}}}");
 
+            output.AppendLine($"const {name}Count = {Names.Length};");
+            output.AppendLine();
+
             if ( isDefault )
             {
                 output.AppendLine($"export default {name};");
+
+                output.AppendLine($"export {{ {name}Count }};");
             }
             else
             {
-                output.AppendLine($"export {{ {name} }};");
+                output.AppendLine($"export {{ {name}, {name}Count }};");
             }
         }
 

--- a/src/TypeData.cs
+++ b/src/TypeData.cs
@@ -328,6 +328,36 @@ namespace Express
             return parents;
         }
 
+        internal IEnumerable<Entity> Children()
+        {
+            var parents = new List<Entity>();
+
+            parents.AddRange(Supers);
+
+            foreach (var s in Supers)
+            {
+                parents.AddRange(s.Children());
+            }
+
+            return parents;
+        }
+
+        internal IEnumerable<Entity> ChildrenAndSelf()
+        {
+            var parents = new List<Entity>();
+
+            parents.Add(this);
+
+            parents.AddRange(Supers);
+
+            foreach (var s in Supers)
+            {
+                parents.AddRange(s.Children());
+            }
+
+            return parents.Distinct();
+        }
+
         /// <summary>
         /// Determine whether this is the provided type or a sub-type of the provided type.
         /// </summary>


### PR DESCRIPTION
* Added children/children and self iteration for iterating through the sub-types
  of a particular type.
* Added a static query list of sub-types to entity types and explicit wrapper types.
* Added static entity expected type ID
* Added abstract types to schema generation.
* Added queries array for looking up queries from type IDs.
* Added count for generated enums.

Related to [#Conway 6](https://github.com/bldrs-ai/conway/issues/6).