### PR TITLE
Reformat gen code

### DIFF
--- a/src/Generators/BldrsEntityGenerator.cs
+++ b/src/Generators/BldrsEntityGenerator.cs
@@ -119,7 +119,7 @@ namespace IFC4.Generators
 $@"
 {importBuilder.ToString()}
 /* This is generated code, don't modify */
-import EntityTypesIfc from ""./entity_types_ifc.bldrs""
+import EntityTypesIfc from ""./entity_types_ifc.gen""
 import StepEntityInternalReference from ""../../core/step_entity_internal_reference""
 import StepEntityBase from ""../../core/step_entity_base""
 import StepModelBase from ""../../core/step_model_base""

--- a/src/Generators/BldrsEntityGenerator.cs
+++ b/src/Generators/BldrsEntityGenerator.cs
@@ -118,31 +118,92 @@ namespace IFC4.Generators
             var result =
 $@"
 {importBuilder.ToString()}
+/* This is generated code, don't modify */
 import EntityTypesIfc from ""./entity_types_ifc.bldrs""
 import StepEntityInternalReference from ""../../core/step_entity_internal_reference""
 import StepEntityBase from ""../../core/step_entity_base""
 import StepModelBase from ""../../core/step_model_base""
-import {{stepExtractBoolean, stepExtractEnum, stepExtractString, stepExtractOptional, stepExtractBinary, stepExtractReference, stepExtractNumber, stepExtractInlineElemement, stepExtractArray, stepExtractLogical, NVL, HIINDEX, SIZEOF}} from '../../../dependencies/conway-ds/src/parsing/step/step_deserialization_functions';
-import {{IfcBaseAxis, IfcBooleanChoose, IfcBuild2Axes, IfcBuildAxes, IfcConstraintsParamBSpline, IfcConvertDirectionInto2D, IfcCorrectDimensions, IfcCorrectFillAreaStyle, IfcCorrectLocalPlacement, IfcCorrectObjectAssignment, IfcCorrectUnitAssignment, IfcCrossProduct, IfcCurveDim, IfcDeriveDimensionalExponents, IfcDimensionsForSiUnit, IfcDotProduct, IfcFirstProjAxis, IfcListToArray, IfcLoopHeadToTail, IfcMakeArrayOfArray, IfcMlsTotalThickness, IfcNormalise, IfcOrthogonalComplement, IfcPathHeadToTail, IfcSameAxis2Placement, IfcSameCartesianPoint, IfcSameDirection, IfcSameValidPrecision, IfcSameValue, IfcScalarTimesVector, IfcSecondProjAxis, IfcShapeRepresentationTypes, IfcTaperedSweptAreaProfiles, IfcTopologyRepresentationTypes, IfcUniqueDefinitionNames, IfcUniquePropertyName, IfcUniquePropertySetNames, IfcUniqueQuantityNames, IfcVectorDifference, IfcVectorSum, IfcPointListDim, IfcGetBasisSurface }} from ""../../core/ifc/ifc_functions""
+import {{
+  stepExtractBoolean,
+  stepExtractEnum,
+  stepExtractString,
+  stepExtractOptional,
+  stepExtractBinary,
+  stepExtractReference,
+  stepExtractNumber,
+  stepExtractInlineElemement,
+  stepExtractArray,
+  stepExtractLogical,
+  NVL,
+  HIINDEX,
+  SIZEOF
+}} from '../../../dependencies/conway-ds/src/parsing/step/step_deserialization_functions'
+
+import {{
+  IfcBaseAxis,
+  IfcBooleanChoose,
+  IfcBuild2Axes,
+  IfcBuildAxes,
+  IfcConstraintsParamBSpline,
+  IfcConvertDirectionInto2D,
+  IfcCorrectDimensions,
+  IfcCorrectFillAreaStyle,
+  IfcCorrectLocalPlacement,
+  IfcCorrectObjectAssignment,
+  IfcCorrectUnitAssignment,
+  IfcCrossProduct,
+  IfcCurveDim,
+  IfcDeriveDimensionalExponents,
+  IfcDimensionsForSiUnit,
+  IfcDotProduct,
+  IfcFirstProjAxis,
+  IfcListToArray,
+  IfcLoopHeadToTail,
+  IfcMakeArrayOfArray,
+  IfcMlsTotalThickness,
+  IfcNormalise,
+  IfcOrthogonalComplement,
+  IfcPathHeadToTail,
+  IfcSameAxis2Placement,
+  IfcSameCartesianPoint,
+  IfcSameDirection,
+  IfcSameValidPrecision,
+  IfcSameValue,
+  IfcScalarTimesVector,
+  IfcSecondProjAxis,
+  IfcShapeRepresentationTypes,
+  IfcTaperedSweptAreaProfiles,
+  IfcTopologyRepresentationTypes,
+  IfcUniqueDefinitionNames,
+  IfcUniquePropertyName,
+  IfcUniquePropertySetNames,
+  IfcUniqueQuantityNames,
+  IfcVectorDifference,
+  IfcVectorSum,
+  IfcPointListDim,
+  IfcGetBasisSurface
+}} from ""../../core/ifc/ifc_functions""
 
 ///**
 // * http://www.buildingsmart-tech.org/ifc/ifc4/final/html/link/{data.Name.ToLower()}.htm */
-export {modifiers} class {data.Name} extends {superClass} 
-{{    
-    public get type(): EntityTypesIfc
-    {{
-        return EntityTypesIfc.{data.Name.ToUpperInvariant()};
-    }}
-{String.Join( '\n', data.Attributes.Where(attribute => !attribute.IsInverse && !attribute.IsDerived).Select( attribute => $"    {BldrsAttributeGenerator.AttributeDataString(attribute, typeData)};" ))}
+export {modifiers} class {data.Name} extends {superClass} {{
+  public get type(): EntityTypesIfc {{
+    return EntityTypesIfc.{data.Name.ToUpperInvariant()}
+  }}
+{String.Join( '\n', data.Attributes.Where(attribute => !attribute.IsInverse && !attribute.IsDerived).Select( attribute => $"  {BldrsAttributeGenerator.AttributeDataString(attribute, typeData)}" ))}
 {propertyBuilder.ToString()}
-    constructor(localID: number, internalReference: StepEntityInternalReference< EntityTypesIfc >, model: StepModelBase< EntityTypesIfc, StepEntityBase< EntityTypesIfc > > )
-    {{
-        super( localID, internalReference, model );
-    }}
+  constructor(
+    localID: number,
+    internalReference: StepEntityInternalReference< EntityTypesIfc >,
+    model: StepModelBase< EntityTypesIfc, StepEntityBase< EntityTypesIfc > > ) {{
+    super( localID, internalReference, model )
+  }}
 
-    public static readonly query = [ { string.Join( ", ", data.ChildrenAndSelf().Where( childEntity => !childEntity.IsAbstract ).Select( childEntity => $"EntityTypesIfc.{childEntity.Name.ToUpperInvariant()}" ) ) } ];
+  public static readonly query = 
+    [ { string.Join( ", ", data.ChildrenAndSelf().Where( childEntity => !childEntity.IsAbstract ).Select( childEntity => $"EntityTypesIfc.{childEntity.Name.ToUpperInvariant()}" ) ) } ]
 
-    public static readonly expectedType: EntityTypesIfc = EntityTypesIfc.{data.Name.ToUpperInvariant()};
+  public static readonly expectedType: EntityTypesIfc =
+    EntityTypesIfc.{data.Name.ToUpperInvariant()}
 }}
 ";
 

--- a/src/Generators/BldrsEnumGenerator.cs
+++ b/src/Generators/BldrsEnumGenerator.cs
@@ -21,14 +21,16 @@ namespace IFC4.Generators
             typeIDGenerator.GenerateHashData(builder, data.Name, null, 0, false);
             builder.AppendLine();
             builder.Append($@"
+/* This is generated cold, don't alter */
+import StepEnumParser from '../../../dependencies/conway-ds/src/parsing/step/step_enum_parser'
 
-import StepEnumParser from '../../../dependencies/conway-ds/src/parsing/step/step_enum_parser';
+const parser = StepEnumParser.Instance
 
-const parser = StepEnumParser.Instance;
-
-export function {data.Name}DeserializeStep( input: Uint8Array, cursor: number, endCursor: number ): {data.Name} | undefined
-{{
-    return parser.extract< {data.Name} >( {data.Name}Search, input, cursor, endCursor );
+export function {data.Name}DeserializeStep(
+  input: Uint8Array,
+  cursor: number,
+  endCursor: number ): {data.Name} | undefined {{
+  return parser.extract< {data.Name} >( {data.Name}Search, input, cursor, endCursor )
 }}
 ");
 

--- a/src/Generators/BldrsGenerator.cs
+++ b/src/Generators/BldrsGenerator.cs
@@ -23,7 +23,7 @@ namespace IFC4.Generators
             SelectData = new Dictionary<string, SelectType>();
         }
 
-        public string FileExtension => "bldrs.ts";
+        public string FileExtension => "gen.ts";
 
         public Dictionary<string, SelectType> SelectData { get; set; }
 

--- a/src/Generators/BldrsStepParserData.cs
+++ b/src/Generators/BldrsStepParserData.cs
@@ -16,7 +16,7 @@ namespace IFC4.Generators
             var typeIDs = new BlrdrsTypeIDGenerator(types, isAbstract);
 
 
-            var enumFileName = "entity_types_ifc.bldrs";
+            var enumFileName = "entity_types_ifc.gen";
             var enumPath = Path.Combine(directory, enumFileName + ".ts" );
             var enumBuilder = new StringBuilder();
 
@@ -24,7 +24,7 @@ namespace IFC4.Generators
                  
             File.WriteAllText(enumPath, enumBuilder.ToString());
 
-            var searchPath = Path.Combine(directory, "entity_types_search.bldrs.ts");
+            var searchPath = Path.Combine(directory, "entity_types_search.gen.ts");
             var searchBuilder = new StringBuilder();
 
             typeIDs.GenerateHashData(searchBuilder, "EntityTypesIfc", enumFileName, 0);
@@ -39,11 +39,11 @@ namespace IFC4.Generators
 
             File.WriteAllText(internalPath, internalBuilder.ToString());
 
-            var schemaFileName = "schema_ifc.bldrs";
+            var schemaFileName = "schema_ifc.gen";
             var schemaPath = Path.Combine(directory, schemaFileName + ".ts");
             var schemaBuilder = new StringBuilder();
 
-            typeIDs.GenerateSchema(schemaBuilder, "SchemaIfc", 0, "EntityTypesIfc", enumFileName, "EntityTypesIfcSearch", "entity_types_search.bldrs");
+            typeIDs.GenerateSchema(schemaBuilder, "SchemaIfc", 0, "EntityTypesIfc", enumFileName, "EntityTypesIfcSearch", "entity_types_search.gen");
             File.WriteAllText(schemaPath, schemaBuilder.ToString());
         }
     }

--- a/src/Generators/BldrsWrapperTypeGenerator.cs
+++ b/src/Generators/BldrsWrapperTypeGenerator.cs
@@ -18,34 +18,47 @@ namespace IFC4.Generators
 
             var result =
 $@"
+/* This is generated code, don't alter */
 {wrappedTypeImport}
 import EntityTypesIfc from ""./entity_types_ifc.bldrs""
 import StepEntityInternalReference from ""../../core/step_entity_internal_reference""
 import StepEntityBase from ""../../core/step_entity_base""
 import StepModelBase from ""../../core/step_model_base""
-import {{stepExtractBoolean, stepExtractEnum, stepExtractString, stepExtractOptional, stepExtractBinary, stepExtractReference, stepExtractNumber, stepExtractInlineElemement, stepExtractArray}} from '../../../dependencies/conway-ds/src/parsing/step/step_deserialization_functions';
+import {{
+  stepExtractBoolean,
+  stepExtractEnum,
+  stepExtractString,
+  stepExtractOptional,
+  stepExtractBinary,
+  stepExtractReference,
+  stepExtractNumber,
+  stepExtractInlineElemement,
+  stepExtractArray
+}} from '../../../dependencies/conway-ds/src/parsing/step/step_deserialization_functions'
 
 
 ///**
 // * http://www.buildingsmart-tech.org/ifc/ifc4/final/html/link/{data.Name.ToLower()}.htm */
-export class {data.Name} extends StepEntityBase< EntityTypesIfc >
-{{    
-    public get type(): EntityTypesIfc
-    {{
-        return EntityTypesIfc.{data.Name.ToUpperInvariant()};
-    }}
+export class {data.Name} extends StepEntityBase< EntityTypesIfc > {{    
+  public get type(): EntityTypesIfc {{
+    return EntityTypesIfc.{data.Name.ToUpperInvariant()}
+  }}
 
-    {BldrsAttributeGenerator.AttributeDataString(valueAttribute, typesData)};
+  {BldrsAttributeGenerator.AttributeDataString(valueAttribute, typesData)};
 {BldrsAttributeGenerator.AttributePropertyString( valueAttribute, 0, typesData, selectData, data.Rank, data.WrappedType, false )}
 
-    constructor(localID: number, internalReference: StepEntityInternalReference< EntityTypesIfc >, model: StepModelBase< EntityTypesIfc, StepEntityBase< EntityTypesIfc > > )
-    {{
-        super( localID, internalReference, model );
-    }}
+  constructor(
+      localID: number,
+      internalReference: StepEntityInternalReference< EntityTypesIfc >,
+      model: StepModelBase< EntityTypesIfc, StepEntityBase< EntityTypesIfc > > ) {{
+     super( localID, internalReference, model )
+  }}
 
-    public static readonly query = [ EntityTypesIfc.{data.Name.ToUpperInvariant()} ];
+  public static readonly query =
+    [ EntityTypesIfc.{data.Name.ToUpperInvariant()} ]
 
-    public static readonly expectedType: EntityTypesIfc = EntityTypesIfc.{data.Name.ToUpperInvariant()};
+  public static readonly expectedType: EntityTypesIfc =
+    EntityTypesIfc.{data.Name.ToUpperInvariant()}
 }}
 ";            return result;
 

--- a/src/Generators/BldrsWrapperTypeGenerator.cs
+++ b/src/Generators/BldrsWrapperTypeGenerator.cs
@@ -20,7 +20,7 @@ namespace IFC4.Generators
 $@"
 /* This is generated code, don't alter */
 {wrappedTypeImport}
-import EntityTypesIfc from ""./entity_types_ifc.bldrs""
+import EntityTypesIfc from ""./entity_types_ifc.gen""
 import StepEntityInternalReference from ""../../core/step_entity_internal_reference""
 import StepEntityBase from ""../../core/step_entity_base""
 import StepModelBase from ""../../core/step_model_base""

--- a/src/Generators/BlrdrsTypeIDGenerator.cs
+++ b/src/Generators/BlrdrsTypeIDGenerator.cs
@@ -47,7 +47,7 @@ namespace IFC4.Generators
 
             foreach ( string name in typesData.Where(nameType => { return nameType.Value is EnumData && !(nameType.Value is SelectType); }).OrderBy(nameType => nameType.Key).Select( nameType => nameType.Key ) )
             { 
-                output.AppendLine($"export {{ {name}, {name}DeserializeStep }} from './{name}.bldrs';");
+                output.AppendLine($"export {{ {name}, {name}DeserializeStep }} from './{name}.bldrs'");
             }
 
             foreach ( string name in Names.OrderBy( name =>
@@ -63,21 +63,22 @@ namespace IFC4.Generators
 
                 }))
             {
-                output.AppendLine($"export {{ {name} }} from './{name}.bldrs';");
+                output.AppendLine($"export {{ {name} }} from './{name}.bldrs'");
             }
         }
 
         public void GenerateSchema(StringBuilder output, string name, int indent, string entityTypesName, string entityTypesFile, string entitySearchTypesName, string entitySearchTypesFile )
         {
-            string indent0 = new string(' ', indent * 4);
-            string indent1 = new string(' ', (indent + 1) * 4);
+            string indent0 = new string(' ', indent * 2);
+            string indent1 = new string(' ', (indent + 1) * 2);
 
-            output.AppendLine($"{indent0}import {entityTypesName} from './{entityTypesFile}';");
-            output.AppendLine($"{indent0}import {entitySearchTypesName} from './{entitySearchTypesFile}';");
-            output.AppendLine($"{indent0}import StepEntityConstructor from '../../core/step_entity_constructor';");
-            output.AppendLine($"{indent0}import StepEntityBase from '../../core/step_entity_base';");
-            output.AppendLine($"{indent0}import StepEntitySchema from '../../core/step_entity_schema';");
-            output.AppendLine($"{indent0}import StepParser from '../../../dependencies/conway-ds/src/parsing/step/step_parser';");
+            output.AppendLine($"/* This is generated code, don't alter */");
+            output.AppendLine($"{indent0}import {entityTypesName} from './{entityTypesFile}'");
+            output.AppendLine($"{indent0}import {entitySearchTypesName} from './{entitySearchTypesFile}'");
+            output.AppendLine($"{indent0}import StepEntityConstructor from '../../core/step_entity_constructor'");
+            output.AppendLine($"{indent0}import StepEntityBase from '../../core/step_entity_base'");
+            output.AppendLine($"{indent0}import StepEntitySchema from '../../core/step_entity_schema'");
+            output.AppendLine($"{indent0}import StepParser from '../../../dependencies/conway-ds/src/parsing/step/step_parser'");
 
             for (int where = 0; where < Names.Length; ++where)
             {
@@ -85,7 +86,7 @@ namespace IFC4.Generators
                 {
                     string localName = Names[where];
 
-                    output.AppendLine($"{indent0}import {{ {localName} }} from './index';");
+                    output.AppendLine($"{indent0}import {{ {localName} }} from './index'");
                 }
             }
 
@@ -105,9 +106,9 @@ namespace IFC4.Generators
                 }
             }
 
-            output.AppendLine($"{indent0}];");
+            output.AppendLine($"{indent0}]");
 
-            output.AppendLine($"{indent0}let queries : {entityTypesName}[][]  = [");
+            output.AppendLine($"{indent0}let queries : {entityTypesName}[][] = [");
 
             for (int where = 0; where < Names.Length; ++where)
             {
@@ -116,21 +117,22 @@ namespace IFC4.Generators
                 output.AppendLine($"{indent1}{localName}.query,");
             }
 
-            output.AppendLine($"{indent0}];");
+            output.AppendLine($"{indent0}]");
 
             output.AppendLine();
-            output.AppendLine($"let parser = new StepParser< {entityTypesName} >( {entitySearchTypesName} );");
+            output.AppendLine($"let parser =\n  new StepParser< {entityTypesName} >( {entitySearchTypesName} )");
             output.AppendLine();
-            output.AppendLine($"let {name} = new StepEntitySchema< {entityTypesName} >( constructors, parser, queries );");
+            output.AppendLine($"let {name} =\n  new StepEntitySchema< {entityTypesName} >( constructors, parser, queries )");
             output.AppendLine();
-            output.AppendLine($"export default {name};");
+            output.AppendLine($"export default {name}");
         }
 
         public void GenerateEnum(StringBuilder output, string name, int indent, bool isDefault )
         {
-            string indent0 = new string(' ', indent * 4);
-            string indent1 = new string(' ', (indent + 1) * 4);
+            string indent0 = new string(' ', indent * 2);
+            string indent1 = new string(' ', (indent + 1) * 2);
 
+            output.AppendLine($"/* This is generated code, don't alter */");
             output.AppendLine($"{indent0}enum {name} {{");
 
             for (int where = 0; where < Names.Length; ++where)
@@ -151,19 +153,20 @@ namespace IFC4.Generators
             }
 
             output.AppendLine($"{indent0}}}");
+            output.AppendLine();
 
-            output.AppendLine($"const {name}Count = {Names.Length};");
+            output.AppendLine($"const {name}Count = {Names.Length}");
             output.AppendLine();
 
             if ( isDefault )
             {
-                output.AppendLine($"export default {name};");
+                output.AppendLine($"export default {name}");
 
-                output.AppendLine($"export {{ {name}Count }};");
+                output.AppendLine($"export {{ {name}Count }}");
             }
             else
             {
-                output.AppendLine($"export {{ {name}, {name}Count }};");
+                output.AppendLine($"export {{ {name}, {name}Count }}");
             }
         }
 
@@ -173,16 +176,17 @@ namespace IFC4.Generators
             string indent0 = new string(' ', indent * 4);
             string indent1 = new string(' ', (indent + 1) * 4);
 
-            output.AppendLine("import MinimalPerfectHash from '../../../dependencies/conway-ds/src/indexing/minimal_perfect_hash';");
+            output.AppendLine("/* This is generated code, don't alter */");
+            output.AppendLine("import MinimalPerfectHash from '../../../dependencies/conway-ds/src/indexing/minimal_perfect_hash'");
 
             if (!String.IsNullOrEmpty(enumFile))
             {
-                output.AppendLine($"import {name} from './{enumFile}';");
+                output.AppendLine($"import {name} from './{enumFile}'");
             }
             
             output.AppendLine();
 
-            output.Append($"{indent0}let gMap{name} = new Int32Array( [");
+            output.Append($"{indent0}let gMap{name} =\n  new Int32Array( [");
 
             for (int where = 0; where < IDTable.GMap.Count; ++where)
             {
@@ -194,10 +198,10 @@ namespace IFC4.Generators
                 output.Append($"{IDTable.GMap[where]}");
             }
 
-            output.AppendLine($"{indent0}] );");
+            output.AppendLine($"{indent0}] )");
             output.AppendLine();
 
-            output.Append($"let prefixSumAddress{name} = new Uint32Array( [");
+            output.Append($"let prefixSumAddress{name} =\n  new Uint32Array( [");
 
             // Prefix sum in hash table order allows us to go straight from hash to string lookup
             for (int where = 0; where < PrefixSumEncoded.Length; ++where)
@@ -210,10 +214,10 @@ namespace IFC4.Generators
                 output.Append($"{PrefixSumEncoded[where]}");
             }
 
-            output.AppendLine($"] );");
+            output.AppendLine($"] )");
             output.AppendLine();
 
-            output.Append($"{indent0}let slotMap{name} = new Int32Array( [");
+            output.Append($"{indent0}let slotMap{name} =\n  new Int32Array( [");
 
             // Slotmap points back to the original IDs
             for (int where = 0; where < IDTable.SlotMap.Count; ++where)
@@ -226,28 +230,28 @@ namespace IFC4.Generators
                 output.Append($"{IDTable.SlotMap[where]}");
             }
 
-            output.AppendLine($"] );");
+            output.AppendLine($"] )");
             output.AppendLine();
-            output.Append($"{indent0}let encodedData{name} = (new TextEncoder()).encode( \"");
+            output.Append($"{indent0}let encodedData{name} =\n  (new TextEncoder()).encode( \"");
 
             foreach ( var encodedKey in IDTable.Keys)
             {
                 output.Append(Encoding.UTF8.GetString(encodedKey));
             }
 
-            output.AppendLine("\" );");
+            output.AppendLine("\" )");
             output.AppendLine();
 
-            output.AppendLine($"{indent0}let {name}Search = new MinimalPerfectHash< {name} >( gMap{name}, prefixSumAddress{name}, slotMap{name}, encodedData{name} );");
+            output.AppendLine($"{indent0}let {name}Search =\n  new MinimalPerfectHash< {name} >( gMap{name}, prefixSumAddress{name}, slotMap{name}, encodedData{name} )");
             output.AppendLine();
 
             if (exportDefault)
             {
-                output.AppendLine($"{indent0}export default {name}Search;");
+                output.AppendLine($"{indent0}export default {name}Search");
             }
             else
             {
-                output.AppendLine($"{indent0}export {{ {name}Search }};");
+                output.AppendLine($"{indent0}export {{ {name}Search }}");
             }
 
         }

--- a/src/Generators/BlrdrsTypeIDGenerator.cs
+++ b/src/Generators/BlrdrsTypeIDGenerator.cs
@@ -40,14 +40,9 @@ namespace IFC4.Generators
 
         public void GenerateInternal(StringBuilder output, Dictionary<string, TypeData> typesData )
         {
-            //foreach (string name in typesData.Where(nameType => { return nameType.Value is WrapperType; }).OrderBy(nameType => nameType.Key).Select(nameType => nameType.Key))
-            //{
-            //    output.AppendLine($"export {{ {name} }} from './{name}.bldrs';");
-            //}
-
             foreach ( string name in typesData.Where(nameType => { return nameType.Value is EnumData && !(nameType.Value is SelectType); }).OrderBy(nameType => nameType.Key).Select( nameType => nameType.Key ) )
             { 
-                output.AppendLine($"export {{ {name}, {name}DeserializeStep }} from './{name}.bldrs'");
+                output.AppendLine($"export {{ {name}, {name}DeserializeStep }} from './{name}.gen'");
             }
 
             foreach ( string name in Names.OrderBy( name =>
@@ -63,7 +58,7 @@ namespace IFC4.Generators
 
                 }))
             {
-                output.AppendLine($"export {{ {name} }} from './{name}.bldrs'");
+                output.AppendLine($"export {{ {name} }} from './{name}.gen'");
             }
         }
 

--- a/src/TypeData.cs
+++ b/src/TypeData.cs
@@ -391,14 +391,17 @@ namespace Express
             }
 
             var propBuilder = new StringBuilder();
+
             foreach (var a in attrs)
             {
                 var prop = a.ToString();
+             
                 if (!string.IsNullOrEmpty(prop))
                 {
                     propBuilder.AppendLine(prop);
                 }
             }
+
             return propBuilder.ToString();
         }
 
@@ -421,6 +424,7 @@ namespace Express
             }
 
             var propBuilder = new StringBuilder();
+
             foreach (var a in attrs)
             {
                 // Attributes which are hidden by a derived attribute
@@ -433,11 +437,13 @@ namespace Express
                 }
 
                 var prop = a.ToStepString(isDerivedInChild);
+
                 if (!string.IsNullOrEmpty(prop))
                 {
                     propBuilder.AppendLine(prop);
                 }
             }
+
             return propBuilder.ToString();
         }
 


### PR DESCRIPTION
* Reformat to make generated code much closer to linter compliant.
* Changed to use ".gen" postfix for generated files instead of ".bldrs" (we can change this again in the future).

Relates to:
[Conway #11](https://github.com/bldrs-ai/conway/issues/11)