### PR TITLE
Permissive array parsing (null as empty array for mandatory array items)

### DIFF
--- a/src/Generators/BldrsAttributeGenerator.cs
+++ b/src/Generators/BldrsAttributeGenerator.cs
@@ -175,7 +175,7 @@ namespace IFC4.Generators
             return "";
         }
 
-        public static string Deserialization( AttributeData data, string assignTo, uint vtableOffsset, Dictionary<string, TypeData> typesData, Dictionary<string, SelectType> selectTypes, bool isCollection, int rank, string type, bool isGeneric, int indent = 0, bool logical = false )
+        public static string Deserialization(AttributeData data, string assignTo, uint vtableOffsset, Dictionary<string, TypeData> typesData, Dictionary<string, SelectType> selectTypes, bool isCollection, int rank, string type, bool isGeneric, int indent = 0, bool logical = false)
         {
             if (isCollection)
             {
@@ -184,7 +184,12 @@ $@"
       if ( stepExtractOptional( buffer, cursor, endCursor ) === null ) {{
         return null
       }}
-" : "";
+" : 
+$@"
+      if ( stepExtractOptional( buffer, cursor, endCursor ) === null ) {{
+        return []
+      }}
+";
 
                 string innerType;
 


### PR DESCRIPTION
This fix pertains to parsing for the bug (https://github.com/bldrs-ai/test-models-private/issues/30). This model crashes due to a non-compliant IFC file that uses the null character ($) for a non-optional array, we add permissiveness to the generated code to fix this by making null characters for a non-optional array return as an empty array.

This is the code-gen portion of https://github.com/bldrs-ai/conway/pull/88.