### PR TITLE
Step gen name sanitizing

### DIFF
--- a/src/Generators/BldrsDerivedFunctionTranslator.cs
+++ b/src/Generators/BldrsDerivedFunctionTranslator.cs
@@ -114,7 +114,9 @@ namespace IFC4.Generators
 
                     if (c == '.')
                     {
-                        string run = input.Substring(runStart, index - runStart);
+                        int runBslash = input.IndexOf('\\', runStart, index - runStart) - runStart;
+                        int runEnd = runBslash >= 0 ? runBslash : ( index - runStart);
+                        string run = input.Substring(runStart, runEnd);
 
                         if (run.Trim() == "SELF")
                         {
@@ -142,7 +144,9 @@ namespace IFC4.Generators
                     }
                     else if (c == ',' || c == ')' || c == ';')
                     {
-                        string run = input.Substring(runStart, index - runStart);
+                        int runBslash = input.IndexOf('\\', runStart, index - runStart) - runStart;
+                        int runEnd = runBslash >= 0 ? runBslash : ( index - runStart);
+                        string run = input.Substring(runStart, runEnd);
 
                         if (run.TrimEnd() == "SELF")
                         {
@@ -162,7 +166,9 @@ namespace IFC4.Generators
                     }
                     else if (c == '(')
                     {
-                        string run = input.Substring(runStart, index - runStart);
+                        int runBslash = input.IndexOf('\\', runStart, index - runStart) - runStart;
+                        int runEnd = runBslash >= 0 ? runBslash : ( index - runStart);
+                        string run = input.Substring(runStart, runEnd);
 
                         result.Append(run);
                         result.Append(c);

--- a/src/Generators/BldrsEnumGenerator.cs
+++ b/src/Generators/BldrsEnumGenerator.cs
@@ -16,9 +16,9 @@ namespace IFC4.Generators
 
             var builder = new StringBuilder();
 
-            typeIDGenerator.GenerateEnum(builder, data.Name, 0, false);
+            typeIDGenerator.GenerateEnum(builder, data.SanitizedName(), 0, false);
             builder.AppendLine();
-            typeIDGenerator.GenerateHashData(builder, data.Name, null, 0, false);
+            typeIDGenerator.GenerateHashData(builder, data.SanitizedName(), null, 0, false);
             builder.AppendLine();
             builder.Append($@"
 /* This is generated cold, don't alter */
@@ -26,11 +26,11 @@ import StepEnumParser from '../../step/parsing/step_enum_parser'
 
 const parser = StepEnumParser.Instance
 
-export function {data.Name}DeserializeStep(
+export function {data.SanitizedName()}DeserializeStep(
   input: Uint8Array,
   cursor: number,
-  endCursor: number ): {data.Name} | undefined {{
-  return parser.extract< {data.Name} >( {data.Name}Search, input, cursor, endCursor )
+  endCursor: number ): {data.SanitizedName()} | undefined {{
+  return parser.extract< {data.SanitizedName()} >( {data.SanitizedName()}Search, input, cursor, endCursor )
 }}
 ");
 

--- a/src/Generators/BldrsGenerator.cs
+++ b/src/Generators/BldrsGenerator.cs
@@ -141,7 +141,7 @@ namespace IFC4.Generators
 
         public void GenerateManifest(string directory, IEnumerable<string> types)
         {
-            var componentTypeNames = Enumerable.Concat( componentTypes_.Select(type => type.Name), wrappedTypes_.Select( type => type.Name ) );
+            var componentTypeNames = Enumerable.Concat( componentTypes_.Select(type => type.SanitizedName()), wrappedTypes_.Select( type => type.SanitizedName()) );
             var abstractTypeNames = Enumerable.Concat( componentTypes_.Select(type => type.IsAbstract), wrappedTypes_.Select( type => false ) );
 
             BldrsStepParserData.GenerateTypeIDFiles(directory, componentTypeNames, abstractTypeNames, TypesData, SelectData);

--- a/src/Generators/BldrsSelectGenerator.cs
+++ b/src/Generators/BldrsSelectGenerator.cs
@@ -17,7 +17,7 @@ namespace IFC4.Generators
                 return new List<string> { baseType };
             }
 
-            var values = selectTypes[baseType].Values;
+            var values = selectTypes[baseType].Values.Select( data => data.SanitizedName() );
             var result = new List<string>();
 
             foreach (var v in values)

--- a/src/Generators/BldrsTypeNameSanitizer.cs
+++ b/src/Generators/BldrsTypeNameSanitizer.cs
@@ -1,0 +1,46 @@
+﻿using Express;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IFC4.Generators
+{
+    public static class BldrsTypeNameSanitizer
+    {
+        public static readonly string[] UnsanitaryNames = new string[]
+        {
+            "class"
+        };
+
+        public static string SanitizedName( this TypeData data )
+        {
+            if ( UnsanitaryNames.Any( value => data.Name == value ) )
+            {
+                return data.Name + "_";
+            }
+
+            return data.Name;
+        }
+        public static string SanitizedName(this string typeName)
+        {
+            if (UnsanitaryNames.Any(value => typeName == value))
+            {
+                return typeName + "_";
+            }
+
+            return typeName;
+        }
+
+        public static string DesanitizedName(this string typeName)
+        {
+            if (UnsanitaryNames.Any(value => typeName == value + "_"))
+            {
+                return typeName.Substring( 0, typeName.Length - 1 );
+            }
+
+            return typeName;
+        }
+    }
+}

--- a/src/Generators/BldrsWrapperTypeGenerator.cs
+++ b/src/Generators/BldrsWrapperTypeGenerator.cs
@@ -36,9 +36,9 @@ import StepModelBase from '../../step/step_model_base'
 
 ///**
 // * http://www.buildingsmart-tech.org/ifc/ifc4/final/html/link/{data.Name.ToLower()}.htm */
-export class {data.Name} extends StepEntityBase< EntityTypesIfc > {{    
+export class {data.SanitizedName()} extends StepEntityBase< EntityTypesIfc > {{    
   public get type(): EntityTypesIfc {{
-    return EntityTypesIfc.{data.Name.ToUpperInvariant()}
+    return EntityTypesIfc.{data.SanitizedName().ToUpperInvariant()}
   }}
 
   {BldrsAttributeGenerator.AttributeDataString(valueAttribute, typesData)};
@@ -52,10 +52,10 @@ export class {data.Name} extends StepEntityBase< EntityTypesIfc > {{
   }}
 
   public static readonly query =
-    [ EntityTypesIfc.{data.Name.ToUpperInvariant()} ]
+    [ EntityTypesIfc.{data.SanitizedName().ToUpperInvariant()} ]
 
   public static readonly expectedType: EntityTypesIfc =
-    EntityTypesIfc.{data.Name.ToUpperInvariant()}
+    EntityTypesIfc.{data.SanitizedName().ToUpperInvariant()}
 }}
 ";            return result;
 

--- a/src/Generators/BlrdrsTypeIDGenerator.cs
+++ b/src/Generators/BlrdrsTypeIDGenerator.cs
@@ -42,12 +42,12 @@ namespace IFC4.Generators
         {
             foreach ( string name in typesData.Where(nameType => { return nameType.Value is EnumData && !(nameType.Value is SelectType); }).OrderBy(nameType => nameType.Key).Select( nameType => nameType.Key ) )
             { 
-                output.AppendLine($"export {{ {name}, {name}DeserializeStep }} from './{name}.gen'");
+                output.AppendLine($"export {{ {name}, {name}DeserializeStep }} from './{name.DesanitizedName()}.gen'");
             }
 
             foreach ( string name in Names.OrderBy( name =>
                 {
-                    var typeData = typesData[name];
+                    var typeData = typesData[name.DesanitizedName()];
 
                     if (typeData is Entity entity)
                     {
@@ -58,7 +58,7 @@ namespace IFC4.Generators
 
                 }))
             {
-                output.AppendLine($"export {{ {name} }} from './{name}.gen'");
+                output.AppendLine($"export {{ {name} }} from './{name.DesanitizedName()}.gen'");
             }
         }
 
@@ -134,19 +134,21 @@ namespace IFC4.Generators
 
             foreach ( var attribute in entity.Attributes )
             {
-                output.Append($"{attributeIndent}{attribute.Name}: ");
+                string cleanName = BldrsAttributeGenerator.CleanName(attribute);
+
+                output.Append($"{attributeIndent}{cleanName}: ");
 
                 GenerateAttributeDescription(output, attribute.type, typesData, selectTypes, attributeIndent, attribute.IsOptional, attribute.IsDerived, attribute.IsCollection, attribute.Rank, false, baseFieldOffset++);
             }
 
             output.AppendLine($"{indent}  }},");
-            output.AppendLine($"{indent}  typeId: e.{entity.Name.ToUpperInvariant()},");
+            output.AppendLine($"{indent}  typeId: e.{entity.SanitizedName().ToUpperInvariant()},");
             output.AppendLine($"{indent}  isAbstract: {(entity.IsAbstract ? "true" : "false")},");
 
             // The terminology for IFC-gen is actually backwards re super and sub-types.
             if ( entity.Subs.Count > 0 )
             {
-                output.AppendLine($"{indent}  superType: e.{entity.Subs[0].Name.ToUpperInvariant()},");
+                output.AppendLine($"{indent}  superType: e.{entity.Subs[0].SanitizedName().ToUpperInvariant()},");
             }
             
             if (entity.Supers.Count > 0)
@@ -155,7 +157,7 @@ namespace IFC4.Generators
 
                 foreach (var super in entity.Supers)
                 {
-                    output.AppendLine($"{indent}     e.{super.Name.ToUpperInvariant()},");
+                    output.AppendLine($"{indent}     e.{super.SanitizedName().ToUpperInvariant()},");
                 }
 
                 output.AppendLine($"{indent}  ],");
@@ -177,7 +179,7 @@ namespace IFC4.Generators
             GenerateAttributeDescription(output, wrapperType.WrappedType, typesData, selectTypes, attributeIndent, false, false, wrapperType.IsCollectionType, wrapperType.Rank, false, 0);
 
             output.AppendLine($"{indent}  }},");
-            output.AppendLine($"{indent}  typeId: e.{wrapperType.Name.ToUpperInvariant()},");
+            output.AppendLine($"{indent}  typeId: e.{wrapperType.SanitizedName().ToUpperInvariant()},");
             output.AppendLine($"{indent}  isAbstract: false,");
             output.AppendLine($"{indent}}},");
         }
@@ -208,7 +210,7 @@ namespace IFC4.Generators
 
             foreach ( var enumType in typesData.Values.Where( type => type is EnumData && !(type is SelectType)).Select( type => type as EnumData).OrderBy( type => type.Name ) )
             {
-                output.AppendLine($"{indent0}import {{ {enumType.Name} }} from './index'");
+                output.AppendLine($"{indent0}import {{ {enumType.SanitizedName()} }} from './index'");
             }
 
             output.AppendLine($"{indent0}let constructors : ( StepEntityConstructor< {entityTypesName}, StepEntityBase< {entityTypesName} > > | undefined )[]  = [");
@@ -248,7 +250,7 @@ namespace IFC4.Generators
             {
                 string localName = Names[where];
 
-                var typeData = typesData[localName];
+                var typeData = typesData[localName.DesanitizedName()];
 
                 if (typeData is Entity entity)
                 {


### PR DESCRIPTION
Fixes several naming hygiene issues with code generation for AP214, including

- Adding sanitized names for types to handle reserved/keywords (https://github.com/bldrs-ai/conway/issues/102)
- Adding sanitized names in derived functions by removing the cast operators (https://github.com/bldrs-ai/conway/issues/104)
- Added name cleaning for handling some of the first steps of mix-ins etc that have decorated names. (https://github.com/bldrs-ai/conway/issues/100).